### PR TITLE
revert: remove ícones dos títulos dos arquivos markdown

### DIFF
--- a/examples/auth-system.md
+++ b/examples/auth-system.md
@@ -1,4 +1,4 @@
-# 🔐 Sistema de Autenticação
+# Sistema de Autenticação
 
 ## Requisitos Funcionais
 

--- a/examples/chat-system.md
+++ b/examples/chat-system.md
@@ -1,4 +1,4 @@
-# 💬 Sistema de Chat
+# Sistema de Chat
 
 ## Requisitos Funcionais
 

--- a/examples/distributed-cache.md
+++ b/examples/distributed-cache.md
@@ -1,4 +1,4 @@
-# 🗄️ Cache Distribuído
+# Cache Distribuído
 
 ## Requisitos Funcionais
 

--- a/examples/log-processing.md
+++ b/examples/log-processing.md
@@ -1,4 +1,4 @@
-# 📊 Sistema de Processamento de Logs
+# Sistema de Processamento de Logs
 
 ## Requisitos Funcionais
 

--- a/examples/payment-processing-system.md
+++ b/examples/payment-processing-system.md
@@ -1,4 +1,4 @@
-# 💰 Sistema de Processamento de Pagamentos
+# Sistema de Processamento de Pagamentos
 
 ## Requisitos Funcionais
 

--- a/examples/payment-system.md
+++ b/examples/payment-system.md
@@ -1,4 +1,4 @@
-# 💳 Sistema de Pagamento
+# Sistema de Pagamento
 
 ## Requisitos Funcionais
 

--- a/examples/real-time-analytics.md
+++ b/examples/real-time-analytics.md
@@ -1,4 +1,4 @@
-# 📈 Sistema de Analytics em Tempo Real
+# Sistema de Analytics em Tempo Real
 
 ## Requisitos Funcionais
 

--- a/examples/real-time-messaging.md
+++ b/examples/real-time-messaging.md
@@ -1,4 +1,4 @@
-# ⚡ Sistema de Mensagens em Tempo Real
+# Sistema de Mensagens em Tempo Real
 
 ## Requisitos Funcionais
 

--- a/examples/recommendation-system.md
+++ b/examples/recommendation-system.md
@@ -1,4 +1,4 @@
-# 🎯 Sistema de Recomendação
+# Sistema de Recomendação
 
 ## Requisitos Funcionais
 

--- a/examples/search-system.md
+++ b/examples/search-system.md
@@ -1,4 +1,4 @@
-# 🔍 Sistema de Busca
+# Sistema de Busca
 
 ## Requisitos Funcionais
 

--- a/examples/url-shortener.md
+++ b/examples/url-shortener.md
@@ -1,4 +1,4 @@
-# 🔗 Sistema de Encurtamento de URLs
+# Sistema de Encurtamento de URLs
 
 ## Requisitos Funcionais
 

--- a/examples/video-streaming.md
+++ b/examples/video-streaming.md
@@ -1,4 +1,4 @@
-# 📺 Sistema de Streaming de Vídeo
+# Sistema de Streaming de Vídeo
 
 ## Requisitos Funcionais
 


### PR DESCRIPTION
Este PR reverte as alterações feitas anteriormente que adicionaram ícones aos títulos dos arquivos markdown dos exemplos, pois os arquivos ficaram incorretos.